### PR TITLE
fix: treesitter query

### DIFF
--- a/lua/neotest-jdtls/neotest/impl/discover_positions.lua
+++ b/lua/neotest-jdtls/neotest/impl/discover_positions.lua
@@ -19,7 +19,19 @@ M.discover_positions = function(file_path)
 		    )
 		)
 		name: (identifier) @test.name
-	      ) @test.definition
+	      )
+	      @test.definition
+	      ;;  @ParameterizedTest(xx) functions
+	      (method_declaration
+		(modifiers
+		  (annotation
+		    name: (identifier) @annotation
+		      (#any-of? @annotation  "ParameterizedTest" )
+		    )
+		)
+		name: (identifier) @test.name
+	      )
+	      @test.definition
 
 	]]
 


### PR DESCRIPTION
Added support for `@ParameterizedTest(xx)` annotations in method declarations.