### PR TITLE
fix: modify test result key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # neotest-jdtls
 * This plugin provides a jdtls adapter for the [Neotest](https://github.com/rcarriga/neotest) framework.
+* Only supports Junit5 tests.
 
 ### Installation
 
@@ -21,9 +22,12 @@ require("neotest").setup {
 
 
 ```
+
 ### Logging
 - logs are written to `neotest-jdtls.log` within the `~/.local/share/nvim/` directory.
 - log level can be set with `vim.g.neotest_jdtls_log_level`.
+
+
 
 ### Acknowledgements
 - **[neotest-java](https://github.com/rcasia/neotest-java)**


### PR DESCRIPTION
 Added `get_test_key_from_junit_result` and `get_test_key_from_neotest_id` functions to extract test keys from JUnit  and Neotest  test run results. 
