### PR TITLE
Add check for Java file extension in is_test_file

### DIFF
--- a/lua/neotest-jdtls/neotest/impl/is_test_file.lua
+++ b/lua/neotest-jdtls/neotest/impl/is_test_file.lua
@@ -3,6 +3,10 @@ local project = require('neotest-jdtls.utils.project')
 local M = {}
 
 function M.is_test_file(file_path)
+	if not vim.endswith(file_path, ".java") then
+		return false
+	end
+	
 	local current_project = project.get_current_project()
 	local path = vim.uri_from_fname(file_path)
 	local is_test_file = current_project.methods[path] or false

--- a/lua/neotest-jdtls/neotest/impl/root.lua
+++ b/lua/neotest-jdtls/neotest/impl/root.lua
@@ -6,7 +6,7 @@ local M = {}
 function M.root(_)
 	local root_dir = jdtls.root_dir()
 	log.debug('root_dir', root_dir)
-	return root_dir
+	return root_dir or vim.fn.getcwd()
 end
 
 return M

--- a/lua/neotest-jdtls/utils/jdtls.lua
+++ b/lua/neotest-jdtls/utils/jdtls.lua
@@ -16,7 +16,7 @@ end
 function JDTLS.root_dir()
 	-- TODO check why the nio.ls.get_clients is dosent has config property
 	local client = vim.lsp.get_clients({ name = 'jdtls' })[1]
-	return client.config.root_dir
+	return client and client.config.root_dir
 end
 
 ---TODO use this function to execute commands


### PR DESCRIPTION
Hey there,

I noticed issues when working with multiple adapters conflicting with neotest-jdtls. Therefore, I added a check if the file in questing is actually a java source file before trying anything else.

Let me know what you think :)

Great plugin btw!