### PR TITLE
fix: whitespace issue for parameterized junit tests

### DIFF
--- a/lua/neotest-jdtls/junit/result_parser.lua
+++ b/lua/neotest-jdtls/junit/result_parser.lua
@@ -299,6 +299,7 @@ function JunitTestParser.get_test_id_for_junit5_method(projectName, message)
 	end
 	-- log.error('methodName', methodName)
 	if className ~= '' then
+    methodName = methodName:gsub('%s*,%s*', ', ')
 		return projectName .. '@' .. className .. methodName, invocationSuffix
 	else
 		return projectName .. '@' .. message, invocationSuffix


### PR DESCRIPTION
This commit resolves an issue where the plugin crashes when executing and parsing the test results.
e.g.:

generated ID for lookup:
domain@some.package.SomeTest#test42(String,String)

test_item in lookup table has ID:
domain@some.package.SomeTest#test42(String, String)

The missing whitespace in param list causes a missmatch and eventually a nil value for the test_item.

The provided solution normalizes the parameter list.